### PR TITLE
Fixing spelling mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ using the `until_with_max_attempts` method which is added to the Object class.
 
 ### Auto Attribute Permitting
 
-To permit attribtues to be bulk assigned, we often see `params.permit(:field1, :field2)`
+To permit attributes to be bulk assigned, we often see `params.permit(:field1, :field2)`
 in our controllers. This automatic method will permit the fields which are included
 in the form to be saved in a secure manner.
 


### PR DESCRIPTION
Hey :wave: 

Randomly came across your repo and it seems like a good idea, plenty of little nifty things to help around especially when you're just hacking around so thanks for writing it :heart: 

I noticed a small spelling mistake in the README and thought I'd correct it :smile: 

Thanks,
.FxN 
