### PR TITLE
Use SecureRandom as Entropy Source

### DIFF
--- a/lib/nifty/utils/random_string.rb
+++ b/lib/nifty/utils/random_string.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 module Nifty
   module Utils
     class RandomString
@@ -16,7 +18,7 @@ module Nifty
         chars += SYMBOLS if options[:symbols]
         (
           [LETTERS[rand(LETTERS.size)]] +
-          (0...options[:length]-2).map{ chars[rand(chars.size)] } +
+          (0...options[:length]-2).map{ chars[SecureRandom.random_number(chars.size)] } +
           [LETTERS[rand(LETTERS.size)]]
         ).join
       end


### PR DESCRIPTION
I keep reading things that don't give me a huge amount of confidence in `rand` and so I tend to alway use `SecureRandom`. 

Any thoughts on swapping over in core?